### PR TITLE
[FEAT] 운동 기록 시에 완등한 문제 항목 추가 버튼 위치 변경

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "300451adae589accbece3490f4396f10bdf15e6e"
+  revision: "54e66469a933b60ddf175f858f82eaeb97e48c8d"
   channel: "stable"
 
 project_type: app
@@ -13,11 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 300451adae589accbece3490f4396f10bdf15e6e
-      base_revision: 300451adae589accbece3490f4396f10bdf15e6e
+      create_revision: 54e66469a933b60ddf175f858f82eaeb97e48c8d
+      base_revision: 54e66469a933b60ddf175f858f82eaeb97e48c8d
     - platform: web
-      create_revision: 300451adae589accbece3490f4396f10bdf15e6e
-      base_revision: 300451adae589accbece3490f4396f10bdf15e6e
+      create_revision: 54e66469a933b60ddf175f858f82eaeb97e48c8d
+      base_revision: 54e66469a933b60ddf175f858f82eaeb97e48c8d
 
   # User provided section
 

--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -38,5 +38,5 @@ class AppConstants {
   static const String reportUrl =
       "https://docs.google.com/forms/d/1Fg3Nk0H3nAoAYAq5elkzUyn69latA9Nv6tJGgD-aENU/edit";
 
-  static const String version = "1.0.0";
+  static const String version = "1.0.1";
 }

--- a/lib/presentation/screens/record/my_record_tab.dart
+++ b/lib/presentation/screens/record/my_record_tab.dart
@@ -1061,9 +1061,7 @@ class _CreateRecordBottomSheetState extends State<_CreateRecordBottomSheet> {
             children: [
               _buildBoulderProblemDropdown(index),
               _buildCountDropdown(index),
-              index == (_boulderProblems.length - 1)
-                  ? _buildPlusButton()
-                  : _buildMinusButton(index),
+              index == 0 ? _buildPlusButton() : _buildMinusButton(index),
             ],
           ),
         );
@@ -1524,9 +1522,7 @@ class _UpdateRecordBottomSheetState extends State<_UpdateRecordBottomSheet> {
             children: [
               _buildBoulderProblemDropdown(index),
               _buildCountDropdown(index),
-              index == (_boulderProblems.length - 1)
-                  ? _buildPlusButton()
-                  : _buildMinusButton(index),
+              index == 0 ? _buildPlusButton() : _buildMinusButton(index),
             ],
           ),
         );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
이제 완등한 문제 첫번째 항목 옆에 항목 추가 버튼이 위치합니다.

## Related Tickets & Documents
- Related Issue #5 
- Closes #5 

## QA Instructions, Screenshots, Recordings
\
<img src="https://github.com/ROCCIA-901/roccia_901_client/assets/71265375/8faae33c-f771-4b67-baf2-5495050ba5cc" width="400" height="150"/>