### PR TITLE
[FIX] 랭킹 스크롤 버그 수정

### DIFF
--- a/lib/constants/app_constants.dart
+++ b/lib/constants/app_constants.dart
@@ -38,5 +38,5 @@ class AppConstants {
   static const String reportUrl =
       "https://docs.google.com/forms/d/1Fg3Nk0H3nAoAYAq5elkzUyn69latA9Nv6tJGgD-aENU/edit";
 
-  static const String version = "1.0.1";
+  static const String version = "1.0.2";
 }

--- a/lib/presentation/screens/record/ranking_tab.dart
+++ b/lib/presentation/screens/record/ranking_tab.dart
@@ -640,28 +640,19 @@ class RankingList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int rank = 0;
-    double? prevScore;
-    int numOfSamePrevScore = 1;
     return ListView.builder(
         padding: EdgeInsets.symmetric(
           horizontal: AppSize.of(context).safeBlockHorizontal * 2.778,
         ),
         itemCount: rankings.length,
         itemBuilder: (BuildContext context, int index) {
-          if (prevScore != rankings[index].score) {
-            rank += numOfSamePrevScore;
-            numOfSamePrevScore = 1;
-            prevScore = rankings[index].score;
-          } else {
-            numOfSamePrevScore++;
-          }
-          return listItem(context, index, rank);
+          return listItem(context, index);
         });
   }
 
-  Widget listItem(BuildContext context, int index, int rank) {
-    return MemberRankingCard(memberRankingData: rankings[index], rank: rank);
+  Widget listItem(BuildContext context, int index) {
+    return MemberRankingCard(
+        memberRankingData: rankings[index], rank: rankings[index].rank);
   }
 }
 

--- a/lib/presentation/viewmodels/ranking/ranking_viewmodel.dart
+++ b/lib/presentation/viewmodels/ranking/ranking_viewmodel.dart
@@ -21,6 +21,7 @@ class RankingProfileState {
   final Location location;
   final String profileImg;
   final double score;
+  final int rank;
 
   RankingProfileState({
     required this.userId,
@@ -30,6 +31,7 @@ class RankingProfileState {
     required this.location,
     required this.profileImg,
     required this.score,
+    required this.rank,
   });
 }
 
@@ -50,9 +52,19 @@ class WeeklyRankingsViewmodel extends _$WeeklyRankingsViewmodel {
     WeeklyRankingsState ret = WeeklyRankingsState.from(
       weeklyRankings.map(
         (weekly) {
+          int rank = 0;
+          double? prevScore;
+          int numOfSamePrevScore = 1;
           return (
             week: weekly.week,
             rankings: weekly.rankings.map((ranking) {
+              if (prevScore != ranking.score) {
+                rank += numOfSamePrevScore;
+                numOfSamePrevScore = 1;
+                prevScore = ranking.score;
+              } else {
+                numOfSamePrevScore++;
+              }
               return RankingProfileState(
                 userId: ranking.userId,
                 username: ranking.username,
@@ -62,6 +74,7 @@ class WeeklyRankingsViewmodel extends _$WeeklyRankingsViewmodel {
                 profileImg: "profile_${ranking.profileImg}",
                 // rank: ranking.rank,
                 score: ranking.score,
+                rank: rank,
               );
             }).toList(),
           );
@@ -93,9 +106,19 @@ class GenerationRankingsViewmodel extends _$GenerationRankingsViewmodel {
     GenerationRankingsState ret = GenerationRankingsState.from(
       generationRankings.map(
         (generation) {
+          int rank = 0;
+          double? prevScore;
+          int numOfSamePrevScore = 1;
           return (
             generation: generation.generation,
             rankings: generation.rankings.map((ranking) {
+              if (prevScore != ranking.score) {
+                rank += numOfSamePrevScore;
+                numOfSamePrevScore = 1;
+                prevScore = ranking.score;
+              } else {
+                numOfSamePrevScore++;
+              }
               return RankingProfileState(
                 userId: ranking.userId,
                 username: ranking.username,
@@ -105,6 +128,7 @@ class GenerationRankingsViewmodel extends _$GenerationRankingsViewmodel {
                 profileImg: "profile_${ranking.profileImg}",
                 // rank: ranking.rank,
                 score: ranking.score,
+                rank: rank,
               );
             }).toList(),
           );


### PR DESCRIPTION
<!-- 출처: https://github.com/forem/forem/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
랭킹 리스트 스크롤 시에 순위 값이 바뀌는 문제를 해결하였습니다. 기존에는 리스트가 스크롤 되면서 **빌드가 되는 시점**에서 순위를 계산하였기 때문에 스크롤을 위아래로 반복하면, 다시 빌드가 되며 **누적해오던 순위값**을 적용 시켜 발생한 문제였습니다. **ViewModel**에서 랭킹 값을 받아오는 시점에 순위를 계산하게 수정하였습니다.

## Related Tickets & Documents
- Closes #7 
